### PR TITLE
testing: Fix test driver code sample typo

### DIFF
--- a/testing/testAutomation/usingTestDrivers/text.md
+++ b/testing/testAutomation/usingTestDrivers/text.md
@@ -13,7 +13,7 @@
 {{ icon_example }} `PayrollTest` ‘drives’ the `Payroll` class by sending it test inputs and verifies if the output is as expected.
 
 ```java
-public class PayrollTestDriver {
+public class PayrollTest {
     public static void main(String[] args) throws Exception {
 
         //test setup


### PR DESCRIPTION
The code sample given for test drivers seems to have a typo in the class name. The paragraph above refers to it as `PayrollTest` but the class name is `PayrollTestDriver`.

This PR fixes the typo.