### PR TITLE
Fix spelling and grammar

### DIFF
--- a/about/usage.md
+++ b/about/usage.md
@@ -161,7 +161,7 @@ Follow [this guide @SE-EDU/guides](https://se-education.org/guides/tutorials/sav
   
 ### Printing
 
-The {{icon_print}} icon indicates printer-friendly versions of each chapter. A printer-friendly version of the entire book can be found [here]({{baseUrl}}/common/print.html)
+The {{icon_print}} icon indicates printer-friendly versions of each chapter. A printer-friendly version of the entire book can be found [here]({{baseUrl}}/common/print.html).
 
 </div>
 

--- a/combined/exercises/interpretClassAndObjectDiagramAllNotations.md
+++ b/combined/exercises/interpretClassAndObjectDiagramAllNotations.md
@@ -1,4 +1,4 @@
-<panel header="{{ icon_Q }} Are you able to interpet CD/OD notations?" expanded>
+<panel header="{{ icon_Q }} Are you able to interpret CD/OD notations?" expanded>
 
 
 <question>

--- a/common/definitions.md
+++ b/common/definitions.md
@@ -97,7 +97,7 @@ e.g., `createEmptyList`, `listOfIntegers`, `htmlText`, `dvdPlayer`. This book de
 
 <div id="def-coupling">
 
-**Coupling**: The degree of interdependence between software modules; a measure of how closely connected two routines or modules are; the strength of the relationships between module.
+**Coupling**: The degree of interdependence between software modules; a measure of how closely connected two routines or modules are; the strength of the relationships between modules.
 
 </div>
 

--- a/cppToJava/classes/classLevelMembers/text.md
+++ b/cppToJava/classes/classLevelMembers/text.md
@@ -98,7 +98,7 @@ public class Bicycle {
 {{ icon_tip }} Explanation of **`System.out.println(...)`**:
 
 * `out` is a class-level public attribute of the `System` class.
-* `println` is a instance level method of the `out` object.
+* `println` is an instance level method of the `out` object.
 
 </box>
 

--- a/cppToJava/classes/definingClasses/q-defineCircleClass.md
+++ b/cppToJava/classes/definingClasses/q-defineCircleClass.md
@@ -1,7 +1,7 @@
 <panel type="dark" header="###  <small><small>{{ icon_important }} [Key Exercise] define a `Circle` class</small></small>" expanded >
 <question>
 
-Define a `Circle` class so that the code given below produces the given output. The nature of the class is a follows:
+Define a `Circle` class so that the code given below produces the given output. The nature of the class is as follows:
 * Attributes(all `private`):
   * **`int x`, `int y`**: represents the location of the circle
   * **`double radius`**: the radius of the circle

--- a/cppToJava/collections/arrayListClass/text.md
+++ b/cppToJava/collections/arrayListClass/text.md
@@ -6,7 +6,7 @@
 
 <div id="body">
 
-The `ArrayList` class is a resizable-array implementation of the `List` interface. Unlike a normal `array`, an `ArrayList` can grow in size as you add more items to it. The example below illustrate some of the useful methods of the `ArrayList` class using an `ArrayList` of `String` objects.
+The `ArrayList` class is a resizable-array implementation of the `List` interface. Unlike a normal `array`, an `ArrayList` can grow in size as you add more items to it. The example below illustrates some of the useful methods of the `ArrayList` class using an `ArrayList` of `String` objects.
 
 ```java
 import java.util.ArrayList;

--- a/cppToJava/dataTypes/variables/text.md
+++ b/cppToJava/dataTypes/variables/text.md
@@ -24,7 +24,7 @@ You can display the value of a variable using `System.out.print` or `System.out.
 
 ```java
 int hour = 11;
-int mintue = 59;
+int minute = 59;
 System.out.print("The current time is ");
 System.out.print(hour);
 System.out.print(":");

--- a/cppToJava/inheritance/interfaces/text.md
+++ b/cppToJava/inheritance/interfaces/text.md
@@ -46,7 +46,7 @@ public class CarModelX implements DrivableVehicle {
 
 </box>
 
-**An interface can be used as a type** e.g., `DrivableVechile dv = new CarModelX();`{.java}.
+**An interface can be used as a type** e.g., `DrivableVechicle dv = new CarModelX();`{.java}.
 
 
 **Interfaces can inherit from other interfaces** using the `extends` keyword, similar to a class inheriting another.

--- a/cppToJava/objects/garbageCollection/text.md
+++ b/cppToJava/objects/garbageCollection/text.md
@@ -11,7 +11,7 @@ What happens when no variables refer to an object?
 Point spot = new Point(3, 4);
 spot = null;
 ```
-The first line creates a new `Point` object and makes spot refer to it. The second line changes `spot` so that instead of referring to the object, it refers to nothing. If there are no references to an object, there is no way to access its attributes or invoke a method on it. From the programmer’s view, it ceases to exist. However it’s still present in the computer’s memory, taking up space.
+The first line creates a new `Point` object and makes spot refer to it. The second line changes `spot` so that instead of referring to the object, it refers to nothing. If there are no references to an object, there is no way to access its attributes or invoke a method on it. From the programmer’s view, it ceases to exist. However, it’s still present in the computer’s memory, taking up space.
 
 {{ different }} **In Java, you don’t have to delete objects you create when they are no longer needed.** As your program runs, the system automatically looks for stranded objects and reclaims them; then the space can be reused for new objects. This process is called _garbage collection_. You don’t have to do anything to make garbage collection happen, and in general don’t have to be aware of it. But in high-performance applications, you may notice a slight delay every now and then when Java reclaims space from discarded objects.
 

--- a/cppToJava/objects/instanceMembers/text.md
+++ b/cppToJava/objects/instanceMembers/text.md
@@ -26,7 +26,7 @@ System.out.println(spot.x + ", " + spot.y + ", " + sum);
 
 </box>
 
-**You can <tooltip content="i.e., change/modify">_mutate_</tooltip> an object by assigning a different values to its attributes.**
+**You can <tooltip content="i.e., change/modify">_mutate_</tooltip> an object by assigning a different value to its attributes.**
 
 <box>
 

--- a/cppToJava/usefulClasses/arraysClass/q-filterEmailsMethod.md
+++ b/cppToJava/usefulClasses/arraysClass/q-filterEmailsMethod.md
@@ -41,7 +41,7 @@ public class Main {
 
 <div slot="hint">
 
-* **`filterEmailsfilterEmails(String[] items): String[]`**
+* **`filterEmails(String[] items): String[]`**
   1. create a new array (say `emails`) of the same size as `items`
   1. go through the elements in the `items` and add to `emails` if the element contains `@` (you can use the `contains` method of the `String` class here)
   1. Use `Arrays.copyOf` method to return the filled part of `emails`.

--- a/errorHandling/assertions/what/text.md
+++ b/errorHandling/assertions/what/text.md
@@ -13,8 +13,8 @@
 {{ icon_example }} An assertion can be used to express something like _when the execution comes to this point, the variable `v` cannot be null_. 
 
 </box>
- 
-**If the runtime detects an _assertion failure_, it typically take some drastic action** such as terminating the execution with an error message. This is because an assertion failure indicates a possible bug and the sooner the execution stops, the safer it is.
+
+**If the runtime detects an _assertion failure_, it typically takes some drastic action** such as terminating the execution with an error message. This is because an assertion failure indicates a possible bug and the sooner the execution stops, the safer it is.
 
 <box>
 

--- a/gitAndGithub/clone/text.md
+++ b/gitAndGithub/clone/text.md
@@ -16,10 +16,10 @@ Suppose you want to clone the sample repo [samplerepo-things](https://github.com
 
 <box type="warning">
 
-Note that the URL of the Github project is different from the URL you need to clone a repo in that Github project.
+Note that the URL of the GitHub project is different from the URL you need to clone a repo in that GitHub project.
 e.g.
 
-Github project URL: `https://github.com/se-edu/samplerepo-things` <br>
+GitHub project URL: `https://github.com/se-edu/samplerepo-things` <br>
 Git repo URL: `https://github.com/se-edu/samplerepo-things.git` (note the `.git` at the end)
 
 </box>

--- a/gitAndGithub/diff/cli_2.md
+++ b/gitAndGithub/diff/cli_2.md
@@ -1,7 +1,7 @@
 The `diff` command can be used to view the differences between two points of the history.
 
 * `git diff`: shows the changes (uncommitted) since the last commit.
-* `git diff 0023cdd..fcd6199`: shows the changes between the points indicated by by commit hashes.<br>
+* `git diff 0023cdd..fcd6199`: shows the changes between the points indicated by commit hashes.<br>
   {{ icon_tip }} Note that when using a commit hash in a Git command, you can use only the first few characters (e.g., first 7-10 chars) as that's usually enough for Git to locate the commit.
 * `git diff v1.0..HEAD`: shows changes that happened from the commit tagged as `v1.0` to the most recent commit.
 

--- a/gitAndGithub/push/cli.md
+++ b/gitAndGithub/push/cli.md
@@ -2,5 +2,5 @@ Use the command `git push origin master`. Enter your Github username and passwor
 
 <box type="warning">
 
-Tags are not included in a normal push. To push a tag, use this command: `git push origin <tag_name>` e.g.. `git push origin v1.0`
+Tags are not included in a normal push. To push a tag, use this command: `git push origin <tag_name>` e.g. `git push origin v1.0`
 </box>

--- a/modeling/modelingBehaviors/activityDiagrams/q-tick-sequence.md
+++ b/modeling/modelingBehaviors/activityDiagrams/q-tick-sequence.md
@@ -1,7 +1,7 @@
 <panel header="{{ icon_Q_A }} Which sequences are not allowed?">
 <question>
 
-Which of these sequence of actions is not allowed by the given activity diagram?
+Which of these sequences of actions is not allowed by the given activity diagram?
 
 - [ ] i. start a b c d end
 - [ ] ii. start a b c d e f g c d end

--- a/modeling/modelingBehaviors/activityDiagramsIntermediate/text.md
+++ b/modeling/modelingBehaviors/activityDiagramsIntermediate/text.md
@@ -9,7 +9,7 @@
 
 <panel type="seamless" src="../../../uml/activityDiagrams/basicNotations/rakes/unit-inElsewhere-asFlat.md#main" boilerplate header="{{ icon_prereq }} UML {{ icon_embedding }} Activity Diagrams → Intermediate Notation → Rakes" alt="{{ icon_prereq }} UML/AD/Rakes" />
 
-<panel type="seamless" src="../../../uml/activityDiagrams/basicNotations/swimlanes/unit-inElsewhere-asFlat.md#main" boilerplate header="{{ icon_prereq }} UML {{ icon_embedding }} Activity Diagrams → Intermedidate Notation → Swim Lanes" alt="{{ icon_prereq }} UML/AD/SwimLanes" />
+<panel type="seamless" src="../../../uml/activityDiagrams/basicNotations/swimlanes/unit-inElsewhere-asFlat.md#main" boilerplate header="{{ icon_prereq }} UML {{ icon_embedding }} Activity Diagrams → Intermediate Notation → Swim Lanes" alt="{{ icon_prereq }} UML/AD/SwimLanes" />
 
 </div>
 

--- a/oop/associations/multiplicity/text.md
+++ b/oop/associations/multiplicity/text.md
@@ -102,7 +102,7 @@ class Bar:
 <box>
 <div class="alt-java">
 
-{{ icon_example }} This code uses an two-dimensional array to implement a 1-to-many association from the `Minefield` to `Cell`.
+{{ icon_example }} This code uses a two-dimensional array to implement a 1-to-many association from the `Minefield` to `Cell`.
 ```java
 class Minefield {
     Cell[][] cell;

--- a/oop/introduction/what/q-tick-trueFalse.md
+++ b/oop/introduction/what/q-tick-trueFalse.md
@@ -10,7 +10,7 @@ OO is a higher level mechanism than the procedural paradigm.
 
 True.
 
-Explanation: Procedural languages work at the simple data structures (e.g., integers, arrays) and functions level. Because an object is an abstraction over data+related functions, OO works at a higher level.
+Explanation: Procedural languages work at the simple data structures (e.g., integers, arrays) and functions level. Because an object is an abstraction over data-related functions, OO works at a higher level.
 
 </div>
 </question>

--- a/oop/more/review/q-radio-abstractionEncapsulation.md
+++ b/oop/more/review/q-radio-abstractionEncapsulation.md
@@ -20,7 +20,7 @@ In the context of OOP, what is the relationship between abstraction and encapsul
 
 c
 
-Explanation: We can have abstraction without encapsulation. For example, we can *think* in terms of student entities when we code in C (a procedural language). But when we use a language that has encapsulation too (e.g., in Java/C++/C#), we can package all student related data and functions into one construct (i.e. a class). This makes the ‘student’ abstraction stronger because now we can not only think in terms of students, the program can perform actions using objects that represent student entities.
+Explanation: We can have abstraction without encapsulation. For example, we can *think* in terms of student entities when we code in C (a procedural language). But when we use a language that has encapsulation too (e.g., in Java/C++/C#), we can package all student related data and functions into one construct (i.e. a class). This makes the ‘student’ abstraction stronger because now we can not only think in terms of students, the program can also perform actions using objects that represent student entities.
 
 </div>
 </question>

--- a/reuse/cloudComputing/services/text.md
+++ b/reuse/cloudComputing/services/text.md
@@ -16,7 +16,7 @@ Cloud computing can deliver computing services at three levels:
 
 2. **Platform as a service (PaaS) provides a platform on which developers can build applications.** Developers do not have to worry about infrastructure issues such as deploying servers or load balancing as is required when using IaaS. Those aspects are automatically taken care of by the platform. The price to pay is reduced flexibility; applications written on PaaS are limited to facilities provided by the platform. %%A PaaS example is the Google App Engine where developers can build applications using Java, Python, PHP, or Go whereas Amazon EC2 allows users to deploy applications written in any language on their virtual servers.%%
 
-3. **Software as a service (SaaS) allows applications to be accessed over the network** instead of installing them on a local machine. %%For example, Google Docs is an SaaS word processing software, while Microsoft Word is a traditional word processing software.%%
+3. **Software as a service (SaaS) allows applications to be accessed over the network** instead of installing them on a local machine. %%For example, Google Docs is a SaaS word processing software, while Microsoft Word is a traditional word processing software.%%
 
 </div>
 

--- a/reuse/introduction/when/text.md
+++ b/reuse/introduction/when/text.md
@@ -6,7 +6,7 @@
 
 <div id="body">
 
-While you may be tempted to use many libraries/frameworks/platform that seem to crop up on a regular basis and promise to bring great benefits, note that **there are costs associated with reuse**. Here are some:
+While you may be tempted to use many libraries/frameworks/platforms that seem to crop up on a regular basis and promise to bring great benefits, note that **there are costs associated with reuse**. Here are some:
 * The reused code **may be an overkill** (think _using a sledgehammer to crack a nut_), increasing the size of, and/or degrading the performance of, your software.
 * The reused software **may not be mature/stable enough** to be used in an important product. That means the software can change drastically and rapidly, possibly in ways that break your software.
 * Non-mature software has the **risk of dying off** as fast as they emerged, leaving you with a dependency that is no longer maintained.

--- a/revisionControl/remoteRepositories/text.md
+++ b/revisionControl/remoteRepositories/text.md
@@ -23,7 +23,7 @@
 </div>
 <div id="section-pushing">
 
-**You can ==_push_== new commits in one repo to another repo** which will copy the new commits onto the destination repo. Note that pushing to a repo requires you to have write-access to it. Furthermore, you can push between repos only if those repos have a shared history among them (i.e, one was created by copying the other at some point in the past).
+**You can ==_push_== new commits in one repo to another repo** which will copy the new commits onto the destination repo. Note that pushing to a repo requires you to have write-access to it. Furthermore, you can push between repos only if those repos have a shared history among them (i.e., one was created by copying the other at some point in the past).
 </div>
 
 Cloning, pushing, and pulling can be done between two local repos too, although it is more common for them to involve a remote repo.

--- a/revisionControl/what/q-tick-rcs-benefits.md
+++ b/revisionControl/what/q-tick-rcs-benefits.md
@@ -2,7 +2,7 @@
 <question>
 
 - [ ] a. Help a single user manage revisions of a single file
-- [ ] b. Help a developer recover from a incorrect modification to a code file
+- [ ] b. Help a developer recover from an incorrect modification to a code file
 - [ ] c. Make it easier for a group of developers to collaborate on a project
 - [ ] d. Manage the drift between multiple versions of your project
 - [ ] e. Detect when multiple developers make incompatible changes to the same file

--- a/specifyingRequirements/supplementaryRequirements/what/text.md
+++ b/specifyingRequirements/supplementaryRequirements/what/text.md
@@ -6,7 +6,7 @@
 
 <div id="body">
 
-**A _supplementary requirements_ section can be used to capture _requirements that do not fit elsewhere_**. Typically, this is where most <trigger trigger="click" for="modal:supplementary-nfr">Non Functional Requirements</trigger> will be listed.
+**A _supplementary requirements_ section can be used to capture _requirements that do not fit elsewhere_**. Typically, this is where most <trigger trigger="click" for="modal:supplementary-nfr">Non-Functional Requirements</trigger> will be listed.
 
 <modal large header="%%Textbook »%%" id="modal:supplementary-nfr">
   <include src="../../../requirements/nonFunctionalRequirements/unit-inElsewhere-asFlat.md" boilerplate/>

--- a/testing/testingTypes/dogfooding/what/q-tick-trueFalse.md
+++ b/testing/testingTypes/dogfooding/what/q-tick-trueFalse.md
@@ -1,4 +1,4 @@
-<panel header="{{ icon_Q_A }} Dogfooding improves product design?">
+<panel header="{{ icon_Q_A }} Can Dogfooding improve product design?">
 <question>
 
 ‘Dogfooding’ can help us improve product designs. 

--- a/uml/activityDiagrams/basicNotations/linearPaths/q-tick-correctNotation.md
+++ b/uml/activityDiagrams/basicNotations/linearPaths/q-tick-correctNotation.md
@@ -15,7 +15,7 @@ Which of these activity diagrams use the correct UML notation?
 <div slot="answer">
 
 * i: :+1: Correct. The arrow-head type does not matter. 
-* ii: Incorrect. The start and end node notation is swapped.
+* ii: Incorrect. The start and end node notations are swapped.
 * iii: Incorrect. Action boxes should have rounded corners.
 * iv: :+1: Correct. An activity can have only one action.
 * v: Incorrect. There cannot be any double-headed arrows.


### PR DESCRIPTION
Mostly trivial fixes, most bugs have been fixed by the previous two PRs. Major kudos to them!

The only worthy change is the proposal to change the exercise header in `Testing` section under `Dogfooding` as follows:
Original header: `Dogfooding improves product design?`
Proposed header: `Can Dogfooding improve product design?`