### PR TITLE
Include code smell under refactoring

### DIFF
--- a/common/references.md
+++ b/common/references.md
@@ -31,7 +31,17 @@ pageNav: 3
   
   * Java: [http://refactoring.com/catalog/](http://refactoring.com/catalog/) -- This is a list of common refactorings maintained by Martin Fowler, a leading authority on refactoring. He is also the author of the ‘bestseller’ on refactoring: [Refactoring: Improving the Design of Existing Code](https://martinfowler.com/books/#refactoring)
   * Python: [https://refactoring.guru/refactoring/catalog](https://refactoring.guru/refactoring/catalog) -- A catalog of refactorings applicable to Python code.
-  
+
+  </span>
+
+* [code-smell-catalog]
+
+  <span id="code-smell-catalog">
+
+  * Code Smell: [https://refactoring.guru/refactoring/smells](https://refactoring.guru/refactoring/smells)  -- A catalog of code smells.
+  * An essay on Code Smell, by Martin Fowler: [https://martinfowler.com/bliki/CodeSmell.html](https://martinfowler.com/bliki/CodeSmell.html) 
+  * A comprehensive list of code smell can be found in [Refactoring: Improving the Design of Existing Code](https://martinfowler.com/books/#refactoring).
+
   </span>
 
 

--- a/refactoring/codeSmell/index.md
+++ b/refactoring/codeSmell/index.md
@@ -1,0 +1,5 @@
+<frontmatter>
+title: "Refactoring: Code Smell"
+</frontmatter>
+
+<include src="unit-inPage-asFlat.md" boilerplate />

--- a/refactoring/codeSmell/text.md
+++ b/refactoring/codeSmell/text.md
@@ -1,0 +1,133 @@
+<span id="prereqs"></span>
+
+<span id="outcomes">{{ icon_outcome }} Can recognize some common code smells</span>
+
+<span id="title">Code Smell</span>
+
+<div id="body">
+
+>“Smells,” you say, “and that is supposed to be better than vague aesthetics?”
+>Well, yes. We have looked at lots of code, written for projects that span the gamut
+>from wildly successful to nearly dead. In doing so, we have learned to look for
+>certain structures in the code that suggest—sometimes, scream for—the possibility
+>of refactoring.
+> - Kent Beck and Martin Fowler, Refactoring
+
+Code smell is a term used to describe the tell-tail signs of bad software and therefore an indication that refactoring is overdue. Similar to design patterns that we learn to recognize and apply in our software, naming and identifying different code smells can help us triage the existing code base and proceed to apply fixes in the form of refactoring.
+
+Given below is a catalog of code smells identified by Martin Fowler. A more comprehensive list is available at <trigger trigger="click" for="modal:refactoring-catalog-codeSmell">code-smell-catalog</trigger>.
+
+<modal header="**Code Smell Catalog**" id="modal:refactoring-catalog-codeSmell">
+  <include src="../../common/references.md#code-smell-catalog"/>
+</modal>
+
+- Alternative Classes with Different Interfaces
+- Comments
+- Data Class
+- Data Clumps
+- Divergent Change
+- Duplicated Code
+- Feature Envy
+- Global Data
+- Insider Trading
+- Large Class
+- Lazy Element
+- Long Function
+- Long Parameter List
+- Loops
+- Message Chains
+- Middle Man
+- Mutable Data
+- Mysterious Name
+- Primitive Obsession
+- Refused Bequest
+- Repeated Switches
+- Shotgun Surgery
+- Speculative Generality
+- Temporary Field
+
+### A Practical Example: Comments
+Comments are helpful when used to make clarifications and explain the purpose of the code. However, comments are also tricky to write because when done poorly, they can be a source of noise and potentially become code smells. Let's take a look at how we can identify smelly comments that prompt us to refactor.
+
+
+<box>
+
+#### Comments that describe what a function does
+
+```java
+// add expenditure to record
+void processInput(int data) {
+	//...
+}
+```
+Possible course of action: Rename function
+```java
+void recordExpenditure(int amount) {
+	//...
+}
+```
+</box>
+
+<box>
+
+#### Comments that describe what a block of code does
+```java
+static Command parseInput(String input) throws InvalidInputException {
+	String task = Parser.tokenize(input)[0];
+	// check if the user input contains recognized keywords
+	boolean hasKeyword = Arrays
+        .stream(TaskType.values())
+        .map(TaskType::getRep)
+        .anyMatch(x -> x.equals(task));
+	if (!hasKeyword) {
+		return false;
+	}
+	return Parser.interpret(input);
+}
+```
+Possible course of action: Extract function
+```java
+private static boolean hasTaskKeyword(String input) {
+	String task = Parser.tokenize(input)[0];
+	return Arrays
+			.stream(TaskType.values())
+			.map(TaskType::getRep)
+			.anyMatch(x -> x.equals(task));
+}
+
+static Command parseInput(String input) throws InvalidInputException {
+	if (!hasTaskKeyword(input)) {
+		throw new InvalidInputException(input);
+	}
+	return Parser.interpret(input);
+}
+```
+
+</box>
+
+<box>
+
+#### Comments that describe assumptions
+```java
+public ShowCommand(Index index) {
+	// note that index must not be null!
+	// and index must be larger or equal to zero!
+	this.index = index;
+}
+```
+Possible course of action: Use assertions
+```java
+public ShowCommand(Index index) {
+	requireNonNull(index);
+	assert index.getZeroBased() >= 0;
+	this.index = index;
+}
+```
+
+</box>
+
+</div>
+
+<div id="extras">
+  <include src="exercises.md" />
+</div>

--- a/refactoring/print.md
+++ b/refactoring/print.md
@@ -13,6 +13,7 @@ title: "Refactoring [Printable]"
 <include src="what/unit-inParent-asFlat-print.md" boilerplate />
 <include src="how/unit-inParent-asFlat-print.md" boilerplate />
 <include src="when/unit-inParent-asFlat-print.md" boilerplate />
+<include src="codeSmell/unit-inParent-asFlat-print.md" boilerplate />
 
 </div>
 

--- a/refactoring/text.md
+++ b/refactoring/text.md
@@ -5,5 +5,5 @@
 <include src="what/unit-inParent-asPanel.md" boilerplate />
 <include src="how/unit-inParent-asPanel.md" boilerplate />
 <include src="when/unit-inParent-asPanel.md" boilerplate />
-
+<include src="codeSmell/unit-inParent-asPanel.md" boilerplate />
 </div>


### PR DESCRIPTION
Code smell might be a worth knowing concept when learning about
refactoring.

Let's include it under refactoring so that learners can be aware of the
term and pick up some ideas on how code smells might indicate a
refactoring is overdue.

I have also added a list of links for code smell under reference.

Fixes #107 

P.S Hi prof, not sure why the deployment failed, if there is any required changes on my end please feel free to let me know. Thank you.