### PR TITLE
cppToJava/inheritance: Fix bug in access modifiers

### DIFF
--- a/cppToJava/inheritance/basic/text.md
+++ b/cppToJava/inheritance/basic/text.md
@@ -145,8 +145,8 @@ There are two levels of access control:
 
 2. **At the member level**:
    * **`public`** : the member is visible to all other classes
+   * **`protected`**: same as `public`
    * **no modifier**: same as `public`
-   * **`protected`**: the member is visible to sub classes only
    * **`private`**: the member is not visible to other classes (but can be accessed in its own class)
 
 </div>


### PR DESCRIPTION
Correct me if I'm wrong, I believe that assuming everything is in the same package, there is no difference between `public` and `protected`