### PR TITLE
Fix spelling of 'example'

### DIFF
--- a/processModels/exampleProcessModels/index.md
+++ b/processModels/exampleProcessModels/index.md
@@ -1,5 +1,5 @@
 <frontmatter>
-title: "SDLC Process Models: Exaxmple Process Models"
+title: "SDLC Process Models: Example Process Models"
 </frontmatter>
 
 <include src="container-inPage-asFlat.md" boilerplate />

--- a/processModels/exampleProcessModels/scrum/index.md
+++ b/processModels/exampleProcessModels/scrum/index.md
@@ -1,5 +1,5 @@
 <frontmatter>
-title: "SDLC Process Models: Exaxmple Process Models: SCRUM"
+title: "SDLC Process Models: Example Process Models: SCRUM"
 </frontmatter>
 
 <include src="unit-inPage-asFlat.md" boilerplate />

--- a/processModels/exampleProcessModels/unifiedProcess/index.md
+++ b/processModels/exampleProcessModels/unifiedProcess/index.md
@@ -1,5 +1,5 @@
 <frontmatter>
-title: "SDLC Process Models: Exaxmple Process Models: Unified Process"
+title: "SDLC Process Models: Example Process Models: Unified Process"
 </frontmatter>
 
 <include src="unit-inPage-asFlat.md" boilerplate />

--- a/processModels/exampleProcessModels/xp/index.md
+++ b/processModels/exampleProcessModels/xp/index.md
@@ -1,5 +1,5 @@
 <frontmatter>
-title: "SDLC Process Models: Exaxmple Process Models: XP"
+title: "SDLC Process Models: Example Process Models: XP"
 </frontmatter>
 
 <include src="unit-inPage-asFlat.md" boilerplate />


### PR DESCRIPTION
The misspelling appears in search results. Not sure if it appears anywhere else.

![image](https://user-images.githubusercontent.com/5585517/211451053-053cddea-972f-4f95-b087-02b7349d3ce6.png)